### PR TITLE
Fix bug within Samsung Browser can.transition

### DIFF
--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -690,7 +690,7 @@ $.fn.transition = function() {
               elementClass = $module.attr('class');
               tagName      = $module.prop('tagName');
 
-              $clone = $('<' + tagName + ' />').addClass( elementClass ).insertAfter($module);
+              $clone = $('<' + tagName + ' />').addClass( elementClass ).appendTo(document.body);
               currentAnimation = $clone
                 .addClass(animation)
                 .removeClass(className.inward)


### PR DESCRIPTION
Fix mobile issue within Samsung Browser within the can.transition method. Somehow getComputedStyle doesn't work and result of "inAnimation" will always return "none". See issue report: https://github.com/Semantic-Org/Semantic-UI/issues/5176